### PR TITLE
update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,15 +8,25 @@ let package = Package(
         .iOS(.v8)
     ],
     products: [
-        .library(
-            name: "SensorsFocus",
-            targets: ["SensorsFocus"]),
+        .library(name: "SensorsFocus", targets: ["SensorsFocusDynamic"]),
+        .library(name: "SensorsFocusDynamicIDMDiagnosis", targets: ["SensorsFocusDynamicIDMDiagnosis"]),
+        .library(name: "SensorsFocusDynamicIDM", targets: ["SensorsFocusDynamicIDM"]),
+        .library(name: "SensorsFocusDynamic", targets: ["SensorsFocusDynamic"]),
+        .library(name: "SensorsFocusDynamicDiagnosis", targets: ["SensorsFocusDynamicDiagnosis"]),
+        .library(name: "SensorsFocusStaticIDMDiagnosis", targets: ["SensorsFocusStaticIDMDiagnosis"]),
+        .library(name: "SensorsFocusStaticIDM", targets: ["SensorsFocusStaticIDM"]),
+        .library(name: "SensorsFocusStatic", targets: ["SensorsFocusStatic"]),
+        .library(name: "SensorsFocusStaticDiagnosis", targets: ["SensorsFocusStaticDiagnosis"]),
     ],
     dependencies: [],
     targets: [
-        .binaryTarget(
-            name: "SensorsFocus",
-            path: "SensorsFocus/SensorsFocus.xcframework"
-        )
+        .binaryTarget(name: "SensorsFocusDynamicIDMDiagnosis", path: "Dynamic+IDM+Diagnosis/SensorsFocus.xcframework"),
+        .binaryTarget(name: "SensorsFocusDynamicIDM", path: "Dynamic+IDM/SensorsFocus.xcframework"),
+        .binaryTarget(name: "SensorsFocusDynamic", path: "Dynamic/SensorsFocus.xcframework"),
+        .binaryTarget(name: "SensorsFocusDynamicDiagnosis", path: "DynamicDiagnosis/SensorsFocus.xcframework"),
+        .binaryTarget(name: "SensorsFocusStaticIDMDiagnosis", path: "Static+IDM+Diagnosis/SensorsFocus.xcframework"),
+        .binaryTarget(name: "SensorsFocusStaticIDM", path: "Static+IDM/SensorsFocus.xcframework"),
+        .binaryTarget(name: "SensorsFocusStatic", path: "Static/SensorsFocus.xcframework"),
+        .binaryTarget(name: "SensorsFocusStaticDiagnosis", path: "StaticDiagnosis/SensorsFocus.xcframework"),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -20,13 +20,12 @@ let package = Package(
     ],
     dependencies: [],
     targets: [
-        .binaryTarget(name: "SensorsFocusDynamicIDMDiagnosis", path: "Dynamic+IDM+Diagnosis/SensorsFocus.xcframework"),
-        .binaryTarget(name: "SensorsFocusDynamicIDM", path: "Dynamic+IDM/SensorsFocus.xcframework"),
-        .binaryTarget(name: "SensorsFocusDynamic", path: "Dynamic/SensorsFocus.xcframework"),
-        .binaryTarget(name: "SensorsFocusDynamicDiagnosis", path: "DynamicDiagnosis/SensorsFocus.xcframework"),
-        .binaryTarget(name: "SensorsFocusStaticIDMDiagnosis", path: "Static+IDM+Diagnosis/SensorsFocus.xcframework"),
-        .binaryTarget(name: "SensorsFocusStaticIDM", path: "Static+IDM/SensorsFocus.xcframework"),
-        .binaryTarget(name: "SensorsFocusStatic", path: "Static/SensorsFocus.xcframework"),
-        .binaryTarget(name: "SensorsFocusStaticDiagnosis", path: "StaticDiagnosis/SensorsFocus.xcframework"),
-    ]
-)
+        .binaryTarget(name: "SensorsFocusDynamicIDMDiagnosis", path: "SensorsFocus/Dynamic+IDM+Diagnosis/SensorsFocus.xcframework"),
+        .binaryTarget(name: "SensorsFocusDynamicIDM", path: "SensorsFocus/Dynamic+IDM/SensorsFocus.xcframework"),
+        .binaryTarget(name: "SensorsFocusDynamic", path: "SensorsFocus/Dynamic/SensorsFocus.xcframework"),
+        .binaryTarget(name: "SensorsFocusDynamicDiagnosis", path: "SensorsFocus/DynamicDiagnosis/SensorsFocus.xcframework"),
+        .binaryTarget(name: "SensorsFocusStaticIDMDiagnosis", path: "SensorsFocus/Static+IDM+Diagnosis/SensorsFocus.xcframework"),
+        .binaryTarget(name: "SensorsFocusStaticIDM", path: "SensorsFocus/Static+IDM/SensorsFocus.xcframework"),
+        .binaryTarget(name: "SensorsFocusStatic", path: "SensorsFocus/Static/SensorsFocus.xcframework"),
+        .binaryTarget(name: "SensorsFocusStaticDiagnosis", path: "SensorsFocus/StaticDiagnosis/SensorsFocus.xcframework"),
+    ])


### PR DESCRIPTION
https://github.com/sensorsdata/sf-sdk-ios/issues/8
The library was recently updated to include several binary products, yet the Package.swift file still declares only a single binary product, resulting in dependency integration issues. The following binary products are currently included in the library update:
Dynamic+IDM+Diagnosis/SensorsFocus.xcframework
Dynamic+IDM/SensorsFocus.xcframework
Dynamic/SensorsFocus.xcframework
DynamicDiagnosis/SensorsFocus.xcframework
Static+IDM+Diagnosis/SensorsFocus.xcframework
Static+IDM/SensorsFocus.xcframework
Static/SensorsFocus.xcframework
StaticDiagnosis/SensorsFocus.xcframework

Proposed Solution:
To resolve this issue, update the Package.swift file to include declarations for all the newly introduced binary products, ensuring they can be correctly located and utilized when adding the package as a dependency. This will allow seamless integration and access to all available binaries within the library.